### PR TITLE
feat: stop generation when llm outputs bos or eos

### DIFF
--- a/run-vllm.py
+++ b/run-vllm.py
@@ -49,11 +49,17 @@ def callback(
     llm = callback.llm
     tokenizer = callback.tokenizer
 
+    stop = params.get("stop", []).copy()
+    if callback.tokenizer.eos_token is not None:
+        stop.append(tokenizer.eos_token)
+    if callback.tokenizer.bos_token is not None:
+        stop.append(tokenizer.bos_token)
     sampling_params = SamplingParams(
         temperature=params["temperature"],
         top_p=params["top_p"],
         max_tokens=params.get("max_tokens", 300),
-        stop=params.get("stop", []),
+        skip_special_tokens=False,
+        stop=stop,
     )
     if mode == "completion":
         for t in tasks:


### PR DESCRIPTION
To match `run-hf.py` behavior, `run-vllm.py` also stops decoding when generating eos or bos.