### PR TITLE
Support `temperature==0.0` case when using `run-hf.py`

### DIFF
--- a/run-hf.py
+++ b/run-hf.py
@@ -90,7 +90,7 @@ class Callback:
                 outputs = model.generate(
                     **{k: v.to(model.device) for k, v in inputs.items()},
                     max_new_tokens=params.get("max_tokens", 300),
-                    do_sample=do_sample,
+                    do_sample=params["temperature"] != 0.0,
                     temperature=params["temperature"] if do_sample else None,
                     top_p=params["top_p"] if do_sample else None,
                     top_k=None,


### PR DESCRIPTION
`run-hf.py`で評価する際に、`--temperature 0`を指定すると以下でfailするのを解決します。
```
`temperature` (=0.0) has to be a strictly positive float, otherwise your next token scores will be invalid. If you're looking for greedy decoding strategies, set `do_sample=False`.
```